### PR TITLE
Use direnv to automatically set the appropriate Node version

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,6 @@
 export GIT_DUET_CO_AUTHORED_BY=1
 
+export NODE_VERSION_PREFIX=v
+export NODE_VERSIONS=~/.nvm/versions/node
+
+use node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
-node_js:
-  - "10"
 
 branches:
   only:


### PR DESCRIPTION
See [**Load Node.js version from a `.node-version` or `.nvmrc` file**][1].

  [1]: https://github.com/direnv/direnv/wiki/Node#load-nodejs-version-from-a-node-version-or-nvmrc-file
