### PR TITLE
Fix migration database access on deployment

### DIFF
--- a/e2e/data/loader.js
+++ b/e2e/data/loader.js
@@ -2,6 +2,8 @@
 const MongoClient = require("mongodb").MongoClient;
 const fs = require("fs");
 
+const { getDatabaseUrl } = require("../../scripts/utils");
+
 function readJsonFile(filename) {
   return new Promise((resolve, reject) => {
     fs.readFile(filename, "utf8", (err, content) => {
@@ -16,9 +18,7 @@ function readJsonFile(filename) {
 }
 
 function mongo() {
-  return MongoClient.connect("mongodb://localhost:27017").then(client =>
-    client.db("flamingo")
-  );
+  return MongoClient.connect(getDatabaseUrl()).then(client => client.db());
 }
 
 function clearReports(db) {

--- a/mm-config.js
+++ b/mm-config.js
@@ -1,4 +1,6 @@
+const { getDatabaseUrl } = require("./scripts/utils");
+
 module.exports = {
-  url: process.env.DATABASE_URL || "mongodb://localhost:27017/flamingo",
+  url: getDatabaseUrl(),
   directory: "./server/migrations"
 };

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "bcrypt": "^3.0.1",
     "body-parser": "^1.18.3",
+    "cf-services": "^2.0.1",
     "connect-mongo": "^2.0.1",
     "debug": "^4.1.0",
     "express": "^4.16.3",

--- a/scripts/generate-reports.js
+++ b/scripts/generate-reports.js
@@ -3,10 +3,9 @@
 /* eslint-disable no-console */
 
 const reportGenerator = require("./reports-generator");
-const databaseUrl
-  = process.env.DATABASE_URL || "mongodb://localhost:27017/flamingo";
+const { getDatabaseUrl } = require("./utils");
 
-reportGenerator(databaseUrl)
+reportGenerator(getDatabaseUrl())
   .then(insertedDocumentCount => {
     console.log(`generated ${insertedDocumentCount} reports`);
     process.exit(0);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,4 +1,14 @@
+const cfServices = require("cf-services");
+
 const stringifyDate = date => new Date(date).toISOString();
+
+const getDatabaseUrl = () => {
+  try {
+    return cfServices("flamongo-db").credentials.uri;
+  } catch (err) {
+    return process.env.DATABASE_URL || "mongodb://localhost:27017/flamingo";
+  }
+};
 
 module.exports = {
   generateReportPeriod: date =>
@@ -6,5 +16,6 @@ module.exports = {
   generateDueDate: reportPeriod => {
     const date = new Date(reportPeriod);
     return stringifyDate(Date.UTC(date.getFullYear(), date.getMonth() + 1, 7));
-  }
+  },
+  getDatabaseUrl
 };

--- a/server/server.js
+++ b/server/server.js
@@ -2,8 +2,8 @@ const connectMongo = require("connect-mongo");
 const debug = require("debug")("server");
 const http = require("http");
 
-const databaseUrl
-  = process.env.DATABASE_URL || "mongodb://localhost:27017/flamingo";
+const { getDatabaseUrl } = require("../scripts/utils");
+
 const port = normalizePort(process.env.PORT || "3000");
 
 const dbModule = require("./db");
@@ -11,7 +11,7 @@ const dbModule = require("./db");
 let server;
 
 dbModule.connect(
-  databaseUrl,
+  getDatabaseUrl(),
   (err, db) => {
     if (err) {
       debug("Unable to connect to Mongo", err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,6 +945,13 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+cf-services@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cf-services/-/cf-services-2.0.1.tgz#e165099176c3970f8d65c2aeaa0aa10ccad07c50"
+  integrity sha1-4WUJkXbDlw+NZcKuqgqhDMrQfFA=
+  dependencies:
+    lodash "^4.17.4"
+
 chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"


### PR DESCRIPTION
Resolve the issue mentioned in https://github.com/HelpRefugees/project-flamingo/wiki/Deployment where the `DATABASE_URL` environment variable is not being set on Cloud Foundry:

 - Uses [`cf-services`](https://www.npmjs.com/package/cf-services) to check for `flamongo-db` before falling back to `DATABASE_URL` then finally the local database
 - Also centralises the database configuration to `scripts/utils.js`