### PR TITLE
Async bcrypt

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -26,11 +26,13 @@ module.exports = {
       new LocalStrategy((username, password, done) => {
         debug("logging in", username);
         db.collection(collection).findOne({ username }, (err, user) => {
-          if (user && bcrypt.compareSync(password, user.password)) {
-            const { username, name, role } = user;
-            return done(null, { username, name, role });
-          }
-          return done(null, false, { message: "Incorrect credentials." });
+          bcrypt.compare(password, user ? user.password : "").then(match => {
+            if (user && match) {
+              const { username, name, role } = user;
+              return done(null, { username, name, role });
+            }
+            return done(null, false, { message: "Incorrect credentials." });
+          });
         });
       })
     );

--- a/server/routes/grants.js
+++ b/server/routes/grants.js
@@ -1,6 +1,7 @@
-const { Router } = require("express");
-const { ensureLoggedIn, ensureHasRole } = require("../auth");
 const bcrypt = require("bcrypt");
+const { Router } = require("express");
+
+const { ensureLoggedIn, ensureHasRole } = require("../auth");
 
 module.exports = db => {
   const collection = "users";
@@ -47,7 +48,9 @@ module.exports = db => {
       const lastGrant = await db
         .collection(collection)
         .findOne({}, { sort: { id: -1 } });
-      const salt = bcrypt.genSaltSync();
+      const password = await bcrypt
+        .genSalt()
+        .then(salt => bcrypt.hash(req.body.accountPassword, salt));
       const newGrant = {
         grant: req.body.grantName,
         name: req.body.organizationName,
@@ -57,7 +60,7 @@ module.exports = db => {
         region: req.body.region,
         otherInfo: req.body.otherInfo,
         username: req.body.accountEmail,
-        password: bcrypt.hashSync(req.body.accountPassword, salt),
+        password,
         role: "implementing-partner",
         id: (lastGrant ? lastGrant.id : 0) + 1
       };

--- a/server/tests/grants_integration.test.js
+++ b/server/tests/grants_integration.test.js
@@ -30,7 +30,8 @@ describe("grants endpoint", () => {
     const appFactory = require("../app");
     app = appFactory(global.DATABASE, session => new session.MemoryStore());
 
-    safeDrop("users");
+    await safeDrop("users");
+    await safeDrop("grants");
 
     await global.DATABASE.collection("users").insertMany([
       {


### PR DESCRIPTION
Always use `bcrypt` asynchronously in the production server code. The sync methods are blocking, so may impact other requests, see [the docs][1].

 [1]: https://www.npmjs.com/package/bcrypt#why-is-async-mode-recommended-over-sync-mode