### PR TITLE
CodeClimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,5 +2,6 @@ version: "2"
 plugins:
   eslint:
     enabled: true
+    channel: "eslint-6"
 exclude_patterns:
   - "client/flow-typed/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+version: "2"
+plugins:
+  eslint:
+    enabled: true
+exclude_patterns:
+  - "client/flow-typed/"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-coverage
-e2e/screenshots
-e2e/videos
-node_modules
-.idea
+.idea/
+coverage/
+e2e/screenshots/
+e2e/videos/
+node_modules/
+cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ script:
   - yarn test:cover
   - yarn e2e:ci
 
+after_script:
+  - ./coverage.sh
+
 before_deploy:
   - yarn build
 
@@ -53,8 +56,3 @@ deploy:
     space: flamingo-prod
     on:
       tags: true
-
-after_script:
-  - ./coverage.sh
-  # prettier-ignore
-  - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,16 +1,25 @@
 #! /usr/bin/env bash
-set -e -x
+set -euo pipefail
 
-./cc-test-reporter format-coverage -o "./coverage/cc.server.json"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPORTER="$HERE/cc-test-reporter"
 
-for DIR in client scripts
-do
-    pushd $DIR
-        ../cc-test-reporter format-coverage -o "../coverage/cc.$DIR.json" --add-prefix $DIR
-    popd
-done
+function format_coverage() {
+    "$REPORTER" format-coverage \
+        "$1/coverage/lcov.info" \
+        --input-type lcov \
+        --output "$HERE/coverage/cc.${2:-server}.json"
+}
 
-PATTERN=coverage/cc.*.json
-FILES=($PATTERN)
+if [[ "${TRAVIS_TEST_RESULT:-0}" == 0 ]]; then
+    format_coverage "$HERE"
+    # client coverage includes C:/Users/Dolan/Documents/docx for some reason...
+    # format_coverage "$HERE/client" 'client'
+    format_coverage "$HERE/scripts" 'scripts'
 
-./cc-test-reporter sum-coverage $PATTERN -p ${#FILES[@]}
+    PATTERN=coverage/cc.*.json
+    FILES=($PATTERN)
+
+    "$REPORTER" sum-coverage $PATTERN -p ${#FILES[@]}
+    "$REPORTER" upload-coverage
+fi


### PR DESCRIPTION
Exclude the flow-typed files from analysis, add ESLint and fix the coverage reporting (or avoid the broken client coverage, at least).